### PR TITLE
Refactor a bit

### DIFF
--- a/dataloader.gemspec
+++ b/dataloader.gemspec
@@ -1,8 +1,10 @@
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 
+require "dataloader/version"
+
 Gem::Specification.new do |s|
   s.name        = "dataloader"
-  s.version     = "0.0.0"
+  s.version     = Dataloader::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Adam Stankiewicz"]
   s.email       = ["sheerun@sher.pl"]

--- a/lib/dataloader.rb
+++ b/lib/dataloader.rb
@@ -13,9 +13,6 @@ end
 
 class Dataloader
   # @!visibility private
-  VERSION = "1.0.0".freeze
-
-  # @!visibility private
   class NoCache
     def compute_if_absent(key)
       yield

--- a/lib/dataloader/version.rb
+++ b/lib/dataloader/version.rb
@@ -1,0 +1,4 @@
+class Dataloader
+  # @!visibility private
+  VERSION = "1.0.0".freeze
+end

--- a/spec/dataloader_spec.rb
+++ b/spec/dataloader_spec.rb
@@ -34,19 +34,6 @@ describe Dataloader do
     expect(two).to eq("awesome 2")
   end
 
-  it "can resolve multiple values" do
-    loader = Dataloader.new do |ids|
-      ids.map { |id| "awesome #{id}" }
-    end
-
-    promise = loader.load_many([1, 2])
-
-    one, two = promise.sync
-
-    expect(one).to eq("awesome 1")
-    expect(two).to eq("awesome 2")
-  end
-
   it "runs loader just one time, even for multiple values" do
     loader = Dataloader.new do |ids|
       ids.map { |_id| ids }


### PR DESCRIPTION
1. Remove duplicated spec. See below:

https://github.com/sheerun/dataloader/blob/3596f03e9f2c127168b34f6553b35e04ef69a7d0/spec/dataloader_spec.rb#L24-L35

https://github.com/sheerun/dataloader/blob/3596f03e9f2c127168b34f6553b35e04ef69a7d0/spec/dataloader_spec.rb#L37-L48

2. Use `Dataloader::VERSION` as gem version. I was surprised the gemspec version is 0.0.0 but there is 1.0.0 in rubygems.org