### PR TITLE
Add Dataloader::GraphQL module to hide Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ QueryType = GraphQL::ObjectType.define do
 end
 
 Schema = GraphQL::Schema.define do
-  lazy_resolve(Promise, :sync)
+  # For graphql >= 1.5.0
+  use Dataloader::GraphQL
+  # Otherwise
+  Dataloader::GraphQL.use(self)
 
   query QueryType
 end

--- a/lib/dataloader.rb
+++ b/lib/dataloader.rb
@@ -93,6 +93,21 @@ class Dataloader
     end
   end
 
+  # Plugin module for {GraphQL}
+  #
+  # @example
+  #   Schema = GraphQL::Schema.define do
+  #     use Dataloader::GraphQL
+  #     query QueryType
+  #   end
+  module GraphQL
+    # @!visibility private
+    # @param defn [GraphQL::Define::DefinedObjectProxy]
+    def self.use(defn)
+      defn.lazy_resolve(Promise, :sync)
+    end
+  end
+
   # Returns the internal cache that can be overridden with `:cache` option (see constructor)
   # This field is writable, so you can reset the cache with something like:
   #

--- a/spec/dataloader_spec.rb
+++ b/spec/dataloader_spec.rb
@@ -449,4 +449,12 @@ describe Dataloader do
 
     expect(one).to be(two)
   end
+
+  describe "::GraphQL.use" do
+    it "calls #lazy_resolve(Promise, :sync) once on the given argument" do
+      double = instance_double("GraphQL::Define::DefinedObjectProxy")
+      expect(double).to receive(:lazy_resolve).with(Promise, :sync).once
+      Dataloader::GraphQL.use(double)
+    end
+  end
 end


### PR DESCRIPTION
I understand dataloader uses promise.rb, but users should not notice it.