### PR TITLE
Added early return for wait when thread has not been initialized

### DIFF
--- a/spec/dataloader_spec.rb
+++ b/spec/dataloader_spec.rb
@@ -1,4 +1,9 @@
 describe Dataloader do
+
+  before(:each) do
+    Thread.current[Dataloader::BATCHES_THREAD_KEY] = nil
+  end
+
   it "can resolve single value" do
     loader = Dataloader.new do |ids|
       ids.map { |id| "awesome #{id}" }
@@ -435,5 +440,11 @@ describe Dataloader do
     two = loader.load(0)
 
     expect(one).to be(two)
+  end
+
+  it 'does not raise an error when Promise.wait is called before a Dataloader has been initialized' do
+    expect {
+      Promise.resolve(true).wait
+    }.not_to raise_error
   end
 end


### PR DESCRIPTION
# What

If `Promise.wait` is used before any Dataloader has been initialized, `Thread.current[:pending_batches]` will not be initialized either. This causes an error because `Dataloader.wait` expects `Thread.current[:pending_batches]` to be an array

# How
This PR fixes the above problem by making an early return in `Dataloader.wait` when `Thread.current[:pending_batches]` is `nil`.

# What was considered
Alternatively we could have initialized `Thread.current[:pending_batches]` in   `Dataloader.wait` as well, but I decided not to do that since it would add another place where `Thread.current[:pending_batches]` value changes, which creates more complexity